### PR TITLE
v0.9.2

### DIFF
--- a/Assets/Materials/Ground.mat
+++ b/Assets/Materials/Ground.mat
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Ground
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _SURFACE_TYPE_TRANSPARENT
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  - DepthOnly
+  - SHADOWCASTER
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0, b: 0, a: 0.5019608}
+    - _Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &896848063298006632
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9

--- a/Assets/Materials/Ground.mat.meta
+++ b/Assets/Materials/Ground.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8748f8bf0cfcfc844add25eef2c2f777
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -192,7 +192,7 @@ Light:
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 5000
-  m_UseColorTemperature: 1
+  m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
@@ -293,6 +293,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1334216156}
+  - {fileID: 1467744629}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &690885152
@@ -591,6 +592,92 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1467744625
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1467744629}
+  - component: {fileID: 1467744628}
+  - component: {fileID: 1467744627}
+  m_Layer: 0
+  m_Name: GroundPlane
+  m_TagString: GroundPlane
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1467744627
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467744625}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8748f8bf0cfcfc844add25eef2c2f777, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1467744628
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467744625}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1467744629
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467744625}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 250, y: 250, z: 250}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 690885150}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1475059024
 GameObject:

--- a/Assets/Scripts/Components/PointData.cs
+++ b/Assets/Scripts/Components/PointData.cs
@@ -29,7 +29,7 @@ namespace KexEdit {
         public int Facing;
 
         public static PointData Create(float velocity = 10f) {
-            return Create(float3.zero, velocity);
+            return Create(new float3(0f, 3f, 0f), velocity);
         }
 
         public static PointData Create(float3 position, float velocity = 10f) {

--- a/Assets/Scripts/Extensions.cs
+++ b/Assets/Scripts/Extensions.cs
@@ -197,8 +197,8 @@ namespace KexEdit {
             return 3f * u * u * (p1 - p0) + 6f * u * t * (p2 - p1) + 3f * t * t * (p3 - p2);
         }
 
-        public static float Evaluate(this DynamicBuffer<RollSpeedKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.RollSpeed.Default(t, anchor);
+        public static float Evaluate(this DynamicBuffer<RollSpeedKeyframe> keyframes, float t) {
+            float defaultValue = PropertyType.RollSpeed.Default(t);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -215,8 +215,8 @@ namespace KexEdit {
             return EvaluateKeyframes(start, end, segmentT);
         }
 
-        public static float Evaluate(this DynamicBuffer<NormalForceKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.NormalForce.Default(t, anchor);
+        public static float Evaluate(this DynamicBuffer<NormalForceKeyframe> keyframes, float t) {
+            float defaultValue = PropertyType.NormalForce.Default(t);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -233,8 +233,8 @@ namespace KexEdit {
             return EvaluateKeyframes(start, end, segmentT);
         }
 
-        public static float Evaluate(this DynamicBuffer<LateralForceKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.LateralForce.Default(t, anchor);
+        public static float Evaluate(this DynamicBuffer<LateralForceKeyframe> keyframes, float t) {
+            float defaultValue = PropertyType.LateralForce.Default(t);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -251,8 +251,8 @@ namespace KexEdit {
             return EvaluateKeyframes(start, end, segmentT);
         }
 
-        public static float Evaluate(this DynamicBuffer<PitchSpeedKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.PitchSpeed.Default(t, anchor);
+        public static float Evaluate(this DynamicBuffer<PitchSpeedKeyframe> keyframes, float t) {
+            float defaultValue = PropertyType.PitchSpeed.Default(t);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -269,8 +269,8 @@ namespace KexEdit {
             return EvaluateKeyframes(start, end, segmentT);
         }
 
-        public static float Evaluate(this DynamicBuffer<YawSpeedKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.YawSpeed.Default(t, anchor);
+        public static float Evaluate(this DynamicBuffer<YawSpeedKeyframe> keyframes, float t) {
+            float defaultValue = PropertyType.YawSpeed.Default(t);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -288,7 +288,7 @@ namespace KexEdit {
         }
 
         public static float Evaluate(this DynamicBuffer<FixedVelocityKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.FixedVelocity.Default(t, anchor);
+            float defaultValue = PropertyType.FixedVelocity.Previous(t, anchor);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -306,7 +306,7 @@ namespace KexEdit {
         }
 
         public static float Evaluate(this DynamicBuffer<HeartKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.Heart.Default(t, anchor);
+            float defaultValue = PropertyType.Heart.Previous(t, anchor);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -324,7 +324,7 @@ namespace KexEdit {
         }
 
         public static float Evaluate(this DynamicBuffer<FrictionKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.Friction.Default(t, anchor);
+            float defaultValue = PropertyType.Friction.Previous(t, anchor);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -342,7 +342,7 @@ namespace KexEdit {
         }
 
         public static float Evaluate(this DynamicBuffer<ResistanceKeyframe> keyframes, float t, in PointData anchor) {
-            float defaultValue = PropertyType.Resistance.Default(t, anchor);
+            float defaultValue = PropertyType.Resistance.Previous(t, anchor);
             if (keyframes.Length == 0) return defaultValue;
             if (t <= keyframes[0].Value.Time) return keyframes[0].Value.Value;
 
@@ -359,7 +359,23 @@ namespace KexEdit {
             return EvaluateKeyframes(start, end, segmentT);
         }
 
-        public static float Default(this PropertyType type, float t, PointData anchor) {
+        public static float Default(this PropertyType type, float t) {
+            PointData defaultPoint = default;
+            return type switch {
+                PropertyType.RollSpeed => 0f,
+                PropertyType.NormalForce => 0f,
+                PropertyType.LateralForce => 0f,
+                PropertyType.PitchSpeed => 0f,
+                PropertyType.YawSpeed => 0f,
+                PropertyType.FixedVelocity => defaultPoint.Velocity,
+                PropertyType.Heart => defaultPoint.Heart,
+                PropertyType.Friction => defaultPoint.Friction,
+                PropertyType.Resistance => defaultPoint.Resistance,
+                _ => throw new System.Exception($"Invalid property type: {type}")
+            };
+        }
+
+        public static float Previous(this PropertyType type, float t, PointData anchor) {
             return type switch {
                 PropertyType.RollSpeed => anchor.RollSpeed,
                 PropertyType.NormalForce => anchor.NormalForce,

--- a/Assets/Scripts/Systems/BuildCurvedSectionSystem.cs
+++ b/Assets/Scripts/Systems/BuildCurvedSectionSystem.cs
@@ -130,7 +130,7 @@ namespace KexEdit {
                     }
 
                     angle += deltaAngle;
-                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(angle, section.Anchor);
+                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(angle);
 
                     UpdateCurvedPoint(section, ref curr, prev, deltaAngle);
                     section.Points.Add(curr);

--- a/Assets/Scripts/Systems/BuildForceSectionSystem.cs
+++ b/Assets/Scripts/Systems/BuildForceSectionSystem.cs
@@ -92,9 +92,9 @@ namespace KexEdit {
                     PointData curr = prev;
 
                     // Assign target constraints values
-                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(t, section.Anchor);
-                    curr.NormalForce = section.NormalForceKeyframes.Evaluate(t, section.Anchor);
-                    curr.LateralForce = section.LateralForceKeyframes.Evaluate(t, section.Anchor);
+                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(t);
+                    curr.NormalForce = section.NormalForceKeyframes.Evaluate(t);
+                    curr.LateralForce = section.LateralForceKeyframes.Evaluate(t);
 
                     UpdateForcePoint(section, ref curr, ref prev);
                     section.Points.Add(curr);
@@ -139,9 +139,9 @@ namespace KexEdit {
 
                     PointData curr = prev;
 
-                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(d, section.Anchor);
-                    curr.NormalForce = section.NormalForceKeyframes.Evaluate(d, section.Anchor);
-                    curr.LateralForce = section.LateralForceKeyframes.Evaluate(d, section.Anchor);
+                    curr.RollSpeed = section.RollSpeedKeyframes.Evaluate(d);
+                    curr.NormalForce = section.NormalForceKeyframes.Evaluate(d);
+                    curr.LateralForce = section.LateralForceKeyframes.Evaluate(d);
 
                     UpdateForcePoint(section, ref curr, ref prev);
                     section.Points.Add(curr);

--- a/Assets/Scripts/Systems/BuildGeometricSectionSystem.cs
+++ b/Assets/Scripts/Systems/BuildGeometricSectionSystem.cs
@@ -91,9 +91,9 @@ namespace KexEdit {
 
                     PointData curr = prev;
 
-                    float rollSpeed = section.RollSpeedKeyframes.Evaluate(t, section.Anchor);
-                    float pitchChangeRate = section.PitchSpeedKeyframes.Evaluate(t, section.Anchor);
-                    float yawChangeRate = section.YawSpeedKeyframes.Evaluate(t, section.Anchor);
+                    float rollSpeed = section.RollSpeedKeyframes.Evaluate(t);
+                    float pitchChangeRate = section.PitchSpeedKeyframes.Evaluate(t);
+                    float yawChangeRate = section.YawSpeedKeyframes.Evaluate(t);
 
                     curr.RollSpeed = rollSpeed;
 
@@ -143,9 +143,9 @@ namespace KexEdit {
                     prev.Friction = section.FrictionKeyframes.Evaluate(d, section.Anchor);
                     prev.Resistance = section.ResistanceKeyframes.Evaluate(d, section.Anchor);
 
-                    float rollSpeed = section.RollSpeedKeyframes.Evaluate(d, section.Anchor);
-                    float pitchChangeRate = section.PitchSpeedKeyframes.Evaluate(d, section.Anchor);
-                    float yawChangeRate = section.YawSpeedKeyframes.Evaluate(d, section.Anchor);
+                    float rollSpeed = section.RollSpeedKeyframes.Evaluate(d);
+                    float pitchChangeRate = section.PitchSpeedKeyframes.Evaluate(d);
+                    float yawChangeRate = section.YawSpeedKeyframes.Evaluate(d);
 
                     PointData curr = prev;
                     curr.RollSpeed = rollSpeed;

--- a/Assets/Scripts/UI/Extensions.cs
+++ b/Assets/Scripts/UI/Extensions.cs
@@ -377,6 +377,58 @@ namespace KexEdit.UI {
             return dialog;
         }
 
+        public static FloatField ShowFloatFieldEditor(
+            this VisualElement element,
+            Vector2 position,
+            float initialValue,
+            Action<float> onSave,
+            Action onCancel = null
+        ) {
+            var floatField = new FloatField {
+                value = initialValue,
+                style = {
+                    position = Position.Absolute,
+                    left = position.x,
+                    top = position.y,
+                    width = 60f,
+                }
+            };
+
+            element.Add(floatField);
+            floatField.Focus();
+
+            void CloseEditor() {
+                floatField.parent?.Remove(floatField);
+            }
+
+            void SaveValue() {
+                onSave?.Invoke(floatField.value);
+                CloseEditor();
+            }
+
+            void CancelEdit() {
+                onCancel?.Invoke();
+                CloseEditor();
+            }
+
+            floatField.RegisterCallback<KeyDownEvent>(evt => {
+                if (evt.keyCode == UnityEngine.KeyCode.Return || evt.keyCode == UnityEngine.KeyCode.KeypadEnter) {
+                    SaveValue();
+                    evt.StopPropagation();
+                }
+                else if (evt.keyCode == UnityEngine.KeyCode.Escape) {
+                    CancelEdit();
+                    evt.StopPropagation();
+                }
+            });
+
+            floatField.RegisterCallback<BlurEvent>(_ => {
+                SaveValue();
+            });
+
+            return floatField;
+        }
+
         public static bool IsMouseInMenuHierarchy(VisualElement target, ContextMenu rootMenu) {
             VisualElement current = target;
             while (current != null) {

--- a/Assets/Scripts/UI/Systems/GridSystem.cs
+++ b/Assets/Scripts/UI/Systems/GridSystem.cs
@@ -8,6 +8,9 @@ using Unity.Mathematics;
 namespace KexEdit.UI {
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     public partial class GridSystem : SystemBase {
+        public static GridSystem Instance { get; private set; }
+
+        private GameObject _groundPlane;
         private Material _gridMaterial;
         private GraphicsBuffer _vertexBuffer;
         private GraphicsBuffer _indexBuffer;
@@ -19,24 +22,21 @@ namespace KexEdit.UI {
         private bool _showGrid = true;
         private int _gridSize = 250;
         private float _gridSpacing = 10f;
-        private Color _gridColor = new(0.5f, 0.5f, 0.5f, 0.1f);
+        private Color _gridColor = new(1f, 1f, 1f, 0.05f);
 
-        public static GridSystem Instance { get; private set; }
-
-        public bool ShowGrid {
-            get => _showGrid;
-            set => _showGrid = value;
-        }
+        public bool ShowGrid => _showGrid;
 
         public GridSystem() {
             Instance = this;
         }
 
         protected override void OnStartRunning() {
+            _groundPlane = GameObject.Find("GroundPlane");
             _bounds = new Bounds(Vector3.zero, Vector3.one * 10000f);
             _camera = UnityEngine.Camera.main;
             CreateGridMaterial();
             GenerateGridMesh();
+            _groundPlane.SetActive(_showGrid);
         }
 
         protected override void OnStopRunning() {
@@ -57,6 +57,7 @@ namespace KexEdit.UI {
                 0f,
                 Mathf.Round(cameraPos.z / _gridSpacing) * _gridSpacing
             );
+            _groundPlane.transform.position = gridCenter;
 
             if (Vector3.Distance(gridCenter, _lastGridCenter) > _gridSpacing * 0.5f) {
                 _lastGridCenter = gridCenter;
@@ -137,6 +138,7 @@ namespace KexEdit.UI {
 
         public void ToggleGrid() {
             _showGrid = !_showGrid;
+            _groundPlane.SetActive(_showGrid);
         }
 
         public void SetGridSettings(int size, float spacing, Color color) {

--- a/Assets/Scripts/UI/Timeline/CurveView.cs
+++ b/Assets/Scripts/UI/Timeline/CurveView.cs
@@ -13,6 +13,7 @@ namespace KexEdit.UI.Timeline {
         private Dictionary<uint, float> _startValues = new();
         private Vector2 _startMousePosition;
         private Vector2 _mousePosition;
+        private Vector2 _lastMouseDownPosition;
         private ValueBounds _startBounds;
         private ValueBounds _dragBounds;
         private KeyframeData _bezierKeyframe;
@@ -54,6 +55,7 @@ namespace KexEdit.UI.Timeline {
             RegisterCallback<MouseDownEvent>(OnMouseDown);
             RegisterCallback<MouseMoveEvent>(OnMouseMove);
             RegisterCallback<MouseUpEvent>(OnMouseUp);
+            RegisterCallback<ClickEvent>(OnClick);
         }
 
         public void Draw() {
@@ -93,6 +95,7 @@ namespace KexEdit.UI.Timeline {
             if (!_data.Active) return;
 
             Focus();
+            _lastMouseDownPosition = evt.localMousePosition;
 
             bool hasKeyframe = TryGetKeyframeAtPosition(
                 _data.ValueBounds,
@@ -201,6 +204,21 @@ namespace KexEdit.UI.Timeline {
                 BoxSelect(rect);
                 _boxSelecting = false;
                 this.ReleaseMouse();
+            }
+        }
+
+        private void OnClick(ClickEvent evt) {
+            if (!_data.Active) return;
+
+            if (evt.clickCount == 2) {
+                bool hasKeyframe = TryGetKeyframeAtPosition(_data.ValueBounds, _lastMouseDownPosition, out KeyframeData keyframe);
+                if (hasKeyframe) {
+                    var e = this.GetPooled<KeyframeDoubleClickEvent>();
+                    e.Keyframe = keyframe;
+                    e.MousePosition = _lastMouseDownPosition;
+                    this.Send(e);
+                    evt.StopPropagation();
+                }
             }
         }
 

--- a/Assets/Scripts/UI/Timeline/DopeSheetView.cs
+++ b/Assets/Scripts/UI/Timeline/DopeSheetView.cs
@@ -12,6 +12,7 @@ namespace KexEdit.UI.Timeline {
         private List<KeyframeData> _selected = new();
         private Dictionary<uint, float> _startTimes = new();
         private Vector2 _startMousePosition;
+        private Vector2 _lastMouseDownPosition;
         private bool _dragging;
         private bool _boxSelecting;
         private bool _moved;
@@ -44,6 +45,7 @@ namespace KexEdit.UI.Timeline {
             RegisterCallback<MouseDownEvent>(OnMouseDown);
             RegisterCallback<MouseMoveEvent>(OnMouseMove);
             RegisterCallback<MouseUpEvent>(OnMouseUp);
+            RegisterCallback<ClickEvent>(OnClick);
         }
 
         private void OnDrawContent(MeshGenerationContext ctx) {
@@ -112,6 +114,7 @@ namespace KexEdit.UI.Timeline {
             if (!_data.Active) return;
 
             Focus();
+            _lastMouseDownPosition = evt.localMousePosition;
 
             bool hasKeyframe = TryGetKeyframeAtPosition(evt.localMousePosition, out KeyframeData keyframe);
             if (evt.button == 0) {
@@ -189,6 +192,21 @@ namespace KexEdit.UI.Timeline {
                 BoxSelect(rect);
                 _boxSelecting = false;
                 this.ReleaseMouse();
+            }
+        }
+
+        private void OnClick(ClickEvent evt) {
+            if (!_data.Active) return;
+
+            if (evt.clickCount == 2) {
+                bool hasKeyframe = TryGetKeyframeAtPosition(_lastMouseDownPosition, out KeyframeData keyframe);
+                if (hasKeyframe) {
+                    var e = this.GetPooled<KeyframeDoubleClickEvent>();
+                    e.Keyframe = keyframe;
+                    e.MousePosition = _lastMouseDownPosition;
+                    this.Send(e);
+                    evt.StopPropagation();
+                }
             }
         }
 

--- a/Assets/Scripts/UI/Timeline/PropertyAdapter.cs
+++ b/Assets/Scripts/UI/Timeline/PropertyAdapter.cs
@@ -136,7 +136,7 @@ namespace KexEdit.UI.Timeline {
         public override string DisplayName => "Roll Speed";
 
         public override float EvaluateAt(Entity entity, float time, Anchor anchor) =>
-            EntityManager.GetBuffer<RollSpeedKeyframe>(entity).Evaluate(time, anchor);
+            EntityManager.GetBuffer<RollSpeedKeyframe>(entity).Evaluate(time);
 
         protected override Keyframe GetData(RollSpeedKeyframe element) => element.Value;
         protected override RollSpeedKeyframe CreateElement(Keyframe keyframe) => keyframe;
@@ -147,7 +147,7 @@ namespace KexEdit.UI.Timeline {
         public override string DisplayName => "Normal Force";
 
         public override float EvaluateAt(Entity entity, float time, Anchor anchor) =>
-            EntityManager.GetBuffer<NormalForceKeyframe>(entity).Evaluate(time, anchor);
+            EntityManager.GetBuffer<NormalForceKeyframe>(entity).Evaluate(time);
 
         protected override Keyframe GetData(NormalForceKeyframe element) => element.Value;
         protected override NormalForceKeyframe CreateElement(Keyframe keyframe) => keyframe;
@@ -158,7 +158,7 @@ namespace KexEdit.UI.Timeline {
         public override string DisplayName => "Lateral Force";
 
         public override float EvaluateAt(Entity entity, float time, Anchor anchor) =>
-            EntityManager.GetBuffer<LateralForceKeyframe>(entity).Evaluate(time, anchor);
+            EntityManager.GetBuffer<LateralForceKeyframe>(entity).Evaluate(time);
 
         protected override Keyframe GetData(LateralForceKeyframe element) => element.Value;
         protected override LateralForceKeyframe CreateElement(Keyframe keyframe) => keyframe;
@@ -169,7 +169,7 @@ namespace KexEdit.UI.Timeline {
         public override string DisplayName => "Pitch Speed";
 
         public override float EvaluateAt(Entity entity, float time, Anchor anchor) =>
-            EntityManager.GetBuffer<PitchSpeedKeyframe>(entity).Evaluate(time, anchor);
+            EntityManager.GetBuffer<PitchSpeedKeyframe>(entity).Evaluate(time);
 
         protected override Keyframe GetData(PitchSpeedKeyframe element) => element.Value;
         protected override PitchSpeedKeyframe CreateElement(Keyframe keyframe) => keyframe;
@@ -180,7 +180,7 @@ namespace KexEdit.UI.Timeline {
         public override string DisplayName => "Yaw Speed";
 
         public override float EvaluateAt(Entity entity, float time, Anchor anchor) =>
-            EntityManager.GetBuffer<YawSpeedKeyframe>(entity).Evaluate(time, anchor);
+            EntityManager.GetBuffer<YawSpeedKeyframe>(entity).Evaluate(time);
 
         protected override Keyframe GetData(YawSpeedKeyframe element) => element.Value;
         protected override YawSpeedKeyframe CreateElement(Keyframe keyframe) => keyframe;

--- a/Assets/Scripts/UI/Timeline/Timeline.cs
+++ b/Assets/Scripts/UI/Timeline/Timeline.cs
@@ -8,6 +8,8 @@ namespace KexEdit.UI.Timeline {
         private VisualElement _divider;
         private TimelineView _view;
 
+        public TimelineView View => _view;
+
         public Timeline() {
             style.position = Position.Absolute;
             style.flexDirection = FlexDirection.RowReverse;

--- a/Assets/Scripts/UI/Timeline/TimelineEvents.cs
+++ b/Assets/Scripts/UI/Timeline/TimelineEvents.cs
@@ -79,6 +79,11 @@ namespace KexEdit.UI.Timeline {
         public bool ShiftKey;
     }
 
+    public class KeyframeDoubleClickEvent : TimelineEvent<KeyframeDoubleClickEvent> {
+        public KeyframeData Keyframe;
+        public Vector2 MousePosition;
+    }
+
     public class ViewClickEvent : TimelineEvent<ViewClickEvent> {
         public Vector2 MousePosition;
         public bool ShiftKey;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Cart
+  - GroundPlane
   layers:
   - Default
   - TransparentFX

--- a/docs/reference/timeline.md
+++ b/docs/reference/timeline.md
@@ -44,16 +44,17 @@ When a node with controllable properties is selected, the Timeline displays:
 
 ## Keyframe Editing
 
-| Input           | Action       | Notes                     |
-| --------------- | ------------ | ------------------------- |
-| `I`             | Insert       | Add keyframe at playhead  |
-| `Left Click`    | Select       | Select keyframe           |
-| `Shift + Click` | Multi-Select | Add to selection          |
-| `Drag`          | Move         | Reposition keyframe       |
-| `Delete`        | Remove       | Delete selected keyframes |
-| `Ctrl+C/V`      | Copy/Paste   | Duplicate keyframes       |
-| `Box Select`    | Multi-Select | Drag to select multiple   |
-| `Right Click`   | Context Menu | Change interpolation type |
+| Input           | Action       | Notes                                     |
+| --------------- | ------------ | ----------------------------------------- |
+| `I`             | Insert       | Add keyframe at playhead                  |
+| `Left Click`    | Select       | Select keyframe                           |
+| `Double Click`  | Edit         | Edit keyframe value                       |
+| `Shift + Click` | Multi-Select | Add to selection                          |
+| `Drag`          | Move         | Reposition keyframe                       |
+| `Delete`        | Remove       | Delete selected keyframes                 |
+| `Ctrl+C/V`      | Copy/Paste   | Duplicate keyframes                       |
+| `Box Select`    | Multi-Select | Drag to select multiple                   |
+| `Right Click`   | Context Menu | Optimize, change interpolation type, etc. |
 
 ## Animation Properties
 

--- a/docs/user-guide/lift-hill.md
+++ b/docs/user-guide/lift-hill.md
@@ -23,8 +23,7 @@ Build the main inclined section with consistent speed and pitch.
 
 1. **Connect Geometric Section** - Drag from curved section output to new **Geometric Section**
 2. **Maintain Speed** - Add **Fixed Velocity** property (inherits previous `3 m/s` value)
-3. **Straighten Section** - Add **Pitch Speed** keyframe set to `0 rad/s`
-4. **Extend Duration** - Increase section length to desired lift hill height
+3. **Extend Duration** - Increase section length to desired lift hill height
 
 ### Top Curve Transition
 


### PR DESCRIPTION
- The ground plane is now slightly opaque, making it clear when the track is below ground level
- Default anchor position is now [0, 3, 0], so that track starts above the ground
- You can now double-click or right click -> edit a keyframe to change its value
- Force and orientation keyframe values are no longer inferred from the previous section. You can still optionally infer it with Right Click -> Reset -> To Previous