### PR TITLE
v0.9.5

### DIFF
--- a/Assets/Scripts/Systems/BuildGeometricSectionSystem.cs
+++ b/Assets/Scripts/Systems/BuildGeometricSectionSystem.cs
@@ -97,10 +97,9 @@ namespace KexEdit {
 
                     curr.RollSpeed = rollSpeed;
 
-                    float deltaTime = 1f / HZ;
-                    float deltaRoll = rollSpeed * deltaTime;
-                    float deltaPitch = pitchChangeRate * deltaTime;
-                    float deltaYaw = yawChangeRate * deltaTime;
+                    float deltaRoll = rollSpeed / HZ;
+                    float deltaPitch = pitchChangeRate / HZ;
+                    float deltaYaw = yawChangeRate / HZ;
 
                     UpdateGeometricPoint(section, ref curr, prev, deltaRoll, deltaPitch, deltaYaw);
                     section.Points.Add(curr);
@@ -150,10 +149,9 @@ namespace KexEdit {
                     PointData curr = prev;
                     curr.RollSpeed = rollSpeed;
 
-                    float deltaTime = 1f / HZ;
-                    float deltaRoll = rollSpeed * deltaTime;
-                    float deltaPitch = pitchChangeRate * deltaTime;
-                    float deltaYaw = yawChangeRate * deltaTime;
+                    float deltaRoll = rollSpeed * (prev.Velocity / HZ);
+                    float deltaPitch = pitchChangeRate * (prev.Velocity / HZ);
+                    float deltaYaw = yawChangeRate * (prev.Velocity / HZ);
 
                     UpdateGeometricPoint(section, ref curr, prev, deltaRoll, deltaPitch, deltaYaw);
                     section.Points.Add(curr);

--- a/Assets/Scripts/UI/NodeGraph/Systems/NodeGraphControlSystem.cs
+++ b/Assets/Scripts/UI/NodeGraph/Systems/NodeGraphControlSystem.cs
@@ -14,6 +14,7 @@ namespace KexEdit.UI.NodeGraph {
     public partial class NodeGraphControlSystem : SystemBase, IEditableHandler {
         private byte[] _clipboardData = null;
         private float2 _clipboardCenter = float2.zero;
+        private float2 _clipboardPan = float2.zero;
         private NodeGraphData _data;
         private NodeGraphView _view;
 
@@ -432,7 +433,7 @@ namespace KexEdit.UI.NodeGraph {
 
             var targetNode = _data.Nodes[evt.Port.Node];
 
-            float2 sourcePosition = targetNode.Position + new float2(-256f, 0f);
+            float2 sourcePosition = targetNode.Position + new float2(-350f, 0f);
             var node = AddNode(sourcePosition, NodeType.Anchor);
 
             var sourcePort = SystemAPI.GetBuffer<OutputPortReference>(node)[0];
@@ -1106,6 +1107,7 @@ namespace KexEdit.UI.NodeGraph {
         private void CopySelectedNodes() {
             _clipboardData = null;
             _clipboardCenter = float2.zero;
+            _clipboardPan = (float2)_data.Pan;
 
             if (!_data.HasSelectedNodes) return;
 
@@ -1275,7 +1277,9 @@ namespace KexEdit.UI.NodeGraph {
                 pasteCenter = (worldPosition.Value - (float2)_data.Pan) / _data.Zoom;
             }
             else {
-                pasteCenter = _clipboardCenter + new float2(100f, 100f);
+                float2 panDelta = (float2)_data.Pan - _clipboardPan;
+                float2 offset = new(50f, 50f);
+                pasteCenter = _clipboardCenter - (panDelta / _data.Zoom) + offset;
             }
             PasteNodes(pasteCenter);
         }

--- a/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
+++ b/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
@@ -110,7 +110,7 @@ namespace KexEdit.UI.Timeline {
             if (!playhead.Active) return;
 
             var pointBuffer = SystemAPI.GetBuffer<Point>(_data.Entity);
-            if (pointBuffer.Length == 0) return;
+            if (pointBuffer.Length < 2) return;
 
             if (SystemAPI.HasComponent<Duration>(_data.Entity)) {
                 var duration = SystemAPI.GetComponent<Duration>(_data.Entity);
@@ -257,11 +257,12 @@ namespace KexEdit.UI.Timeline {
             public PropertyType Type;
 
             public void Execute() {
+                if (Points.Length == 0) return;
+                Values.Clear();
+                Values.ResizeUninitialized(Points.Length);
+
                 for (int i = 0; i < Points.Length; i++) {
                     var point = Points[i].Value;
-                    float time = i / HZ;
-                    Values.Clear();
-                    Values.ResizeUninitialized(Points.Length);
                     switch (Type) {
                         case PropertyType.NormalForce:
                             Values[i] = point.NormalForce;

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.9.4
+  bundleVersion: 0.9.5
   preloadedAssets:
   - {fileID: 0}
   - {fileID: -944628639613478452, guid: e0b2dd823be4b2b4eb9c413d404801d6, type: 3}


### PR DESCRIPTION
- Geometric distance sections now correctly scale values w.r.t. distance instead of time
- Fixed incorrect copy-pasted node position