### PR TITLE
v0.9.12

### DIFF
--- a/Assets/Scripts/Systems/GraphSystem.cs
+++ b/Assets/Scripts/Systems/GraphSystem.cs
@@ -73,7 +73,11 @@ namespace KexEdit {
                     }
                     else if (type == PortType.Position) {
                         float3 position = SystemAPI.GetComponent<PositionPort>(inputPort);
-                        anchor.Value.SetPosition(position);
+                        if (SystemAPI.GetComponent<Node>(nodeEntity).Type == NodeType.Mesh) {
+                            anchor.Value.Position = position;
+                        } else {
+                            anchor.Value.SetPosition(position);
+                        }
                     }
                     else if (type == PortType.Roll) {
                         float roll = SystemAPI.GetComponent<RollPort>(inputPort);

--- a/Assets/Scripts/Systems/MeshLoadingSystem.cs
+++ b/Assets/Scripts/Systems/MeshLoadingSystem.cs
@@ -5,7 +5,7 @@ namespace KexEdit {
     [UpdateInGroup(typeof(InitializationSystemGroup))]
     public partial class MeshLoadingSystem : SystemBase {
         protected override void OnUpdate() {
-            foreach (var (meshReference, entity) in SystemAPI.Query<MeshReference>().WithEntityAccess()) {
+            foreach (var (meshReference, render, entity) in SystemAPI.Query<MeshReference, Render>().WithEntityAccess()) {
                 if (meshReference.Loaded || meshReference.FilePath.IsEmpty || meshReference.Value != null) continue;
                 meshReference.Loaded = true;
                 string filePath = meshReference.FilePath.ToString();
@@ -13,12 +13,14 @@ namespace KexEdit {
                     ImportManager.ImportGltfFileAsync(filePath, managedMesh => {
                         meshReference.Value = managedMesh;
                         managedMesh.Node = entity;
+                        managedMesh.gameObject.SetActive(render.Value);
                     });
                 }
                 else if (filePath.EndsWith(".obj")) {
                     ImportManager.ImportObjFile(filePath, managedMesh => {
                         meshReference.Value = managedMesh;
                         managedMesh.Node = entity;
+                        managedMesh.gameObject.SetActive(render.Value);
                     });
                 }
                 else {

--- a/Assets/Scripts/Systems/MeshUpdateSystem.cs
+++ b/Assets/Scripts/Systems/MeshUpdateSystem.cs
@@ -10,9 +10,13 @@ namespace KexEdit {
         protected override void OnUpdate() {
             _managedMeshes.Clear();
 
-            foreach (var (meshReference, anchor, dirtyRW) in SystemAPI.Query<MeshReference, Anchor, RefRW<Dirty>>()) {
+            foreach (var (meshReference, anchor, render, dirtyRW) in SystemAPI.Query<MeshReference, Anchor, Render, RefRW<Dirty>>()) {
                 if (meshReference.Value == null) continue;
                 _managedMeshes.Add(meshReference.Value);
+
+                meshReference.Value.gameObject.SetActive(render.Value);
+
+                if (!render.Value) continue;
 
                 ref bool dirty = ref dirtyRW.ValueRW.Value;
                 if (!dirty) continue;

--- a/Assets/Scripts/UI/ImportManager.cs
+++ b/Assets/Scripts/UI/ImportManager.cs
@@ -11,7 +11,7 @@ namespace KexEdit.UI {
     public static class ImportManager {
         public static void ShowImportDialog(VisualElement root, Action<string> onSuccess = null) {
             var extensions = new ExtensionFilter[] {
-                new("Mesh", "glb", "gltf"),
+                new("glTF", "glb", "gltf"),
                 new("OBJ", "obj"),
                 new("All Files", "*")
             };

--- a/Assets/Scripts/UI/NodeGraph/NodeGraphNode.cs
+++ b/Assets/Scripts/UI/NodeGraph/NodeGraphNode.cs
@@ -231,7 +231,8 @@ namespace KexEdit.UI.NodeGraph {
                 || _type == NodeType.CurvedSection
                 || _type == NodeType.CopyPathSection
                 || _type == NodeType.Reverse
-                || _type == NodeType.ReversePath) {
+                || _type == NodeType.ReversePath
+                || _type == NodeType.Mesh) {
                 _itemsContainer = new VisualElement {
                     style = {
                         position = Position.Relative,
@@ -261,13 +262,16 @@ namespace KexEdit.UI.NodeGraph {
                 if (_type == NodeType.ForceSection
                     || _type == NodeType.GeometricSection
                     || _type == NodeType.CurvedSection
-                    || _type == NodeType.CopyPathSection) {
+                    || _type == NodeType.CopyPathSection
+                    || _type == NodeType.Mesh) {
                     _renderToggle = new RenderToggle();
                     _itemsContainer.Add(_renderToggle);
                 }
 
-                _priorityField = new PriorityField();
-                _itemsContainer.Add(_priorityField);
+                if (_type != NodeType.Mesh) {
+                    _priorityField = new PriorityField();
+                    _itemsContainer.Add(_priorityField);
+                }
 
                 _collapseButton = new Label("▼") {
                     style = {

--- a/Assets/Scripts/UI/NodeGraph/Systems/NodeGraphControlSystem.cs
+++ b/Assets/Scripts/UI/NodeGraph/Systems/NodeGraphControlSystem.cs
@@ -1074,6 +1074,10 @@ namespace KexEdit.UI.NodeGraph {
                 ecb.AddBuffer<ResistanceKeyframe>(entity);
             }
 
+            if (type == NodeType.Mesh) {
+                ecb.AddComponent<Render>(entity, true);
+            }
+
             if (type == NodeType.ForceSection ||
                 type == NodeType.GeometricSection) {
                 ecb.AddComponent(entity, new Duration {

--- a/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
+++ b/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
@@ -54,11 +54,11 @@ namespace KexEdit.UI.Timeline {
         protected override void OnStartRunning() {
             var root = UIService.Instance.UIDocument.rootVisualElement;
             _timeline = root.Q<Timeline>();
-            
+
             var uiState = SystemAPI.GetSingleton<UIState>();
             _data.Offset = uiState.TimelineOffset;
             _data.Zoom = uiState.TimelineZoom;
-            
+
             _timeline.Initialize(_data);
 
             _timeline.RegisterCallback<CurveButtonClickEvent>(OnCurveButtonClick);
@@ -75,6 +75,7 @@ namespace KexEdit.UI.Timeline {
             _timeline.RegisterCallback<ViewRightClickEvent>(OnViewRightClick);
             _timeline.RegisterCallback<SetKeyframeEvent>(OnSetKeyframe);
             _timeline.RegisterCallback<SetKeyframeAtTimeEvent>(OnSetKeyframeAtTime);
+            _timeline.RegisterCallback<SetKeyframeValueEvent>(OnSetKeyframeValue);
             _timeline.RegisterCallback<JumpToKeyframeEvent>(OnJumpToKeyframe);
             _timeline.RegisterCallback<KeyframeButtonClickEvent>(OnKeyframeButtonClick);
             _timeline.RegisterCallback<DragKeyframesEvent>(OnDragKeyframes);
@@ -1030,7 +1031,6 @@ namespace KexEdit.UI.Timeline {
                         _data.EnableKeyframeEditor = !_data.EnableKeyframeEditor;
                         Preferences.KeyframeEditor = _data.EnableKeyframeEditor;
                     }, isChecked: _data.EnableKeyframeEditor);
-                    menu.AddSeparator();
                     menu.AddSubmenu("Optimize", submenu => {
                         submenu.AddItem("Roll", () => {
                             Undo.Record();
@@ -1082,6 +1082,11 @@ namespace KexEdit.UI.Timeline {
                     menu.AddSeparator();
                 }
 
+                menu.AddItem("Set Value", () => {
+                    var keyframe = GetSelectedKeyframe();
+                    ShowKeyframeValueEditor(keyframe, evt.MousePosition);
+                }, "V");
+                menu.AddSeparator();
                 menu.AddPlatformItem(canCut ? "Cut" : "Cannot Cut", EditOperationsSystem.HandleCut, "Ctrl+X", enabled: canCut && hasSelection);
                 menu.AddPlatformItem(canCopy ? "Copy" : "Cannot Copy", EditOperationsSystem.HandleCopy, "Ctrl+C", enabled: canCopy && hasSelection);
                 menu.AddPlatformItem(canPaste ? "Paste" : "Cannot Paste", EditOperationsSystem.HandlePaste, "Ctrl+V", enabled: canPaste);
@@ -1354,6 +1359,10 @@ namespace KexEdit.UI.Timeline {
                 UnityEngine.Debug.LogError($"No keyframe found for type {evt.Type} with ID {evt.KeyframeId}");
             }
             MarkTrackDirty();
+        }
+
+        private void OnSetKeyframeValue(SetKeyframeValueEvent evt) {
+            ShowKeyframeValueEditor(evt.Keyframe, evt.MousePosition);
         }
 
         private void ResetKeyframe() {

--- a/Assets/Scripts/UI/Timeline/TimelineEvents.cs
+++ b/Assets/Scripts/UI/Timeline/TimelineEvents.cs
@@ -98,6 +98,11 @@ namespace KexEdit.UI.Timeline {
         public float Value;
     }
 
+    public class SetKeyframeValueEvent : TimelineEvent<SetKeyframeValueEvent> {
+        public KeyframeData Keyframe;
+        public Vector2 MousePosition;
+    }
+
     public class SetKeyframeAtTimeEvent : TimelineEvent<SetKeyframeAtTimeEvent> {
         public PropertyType Type;
         public InterpolationType InInterpolation = InterpolationType.Bezier;

--- a/Assets/Scripts/UI/Timeline/TimelineView.cs
+++ b/Assets/Scripts/UI/Timeline/TimelineView.cs
@@ -101,6 +101,7 @@ namespace KexEdit.UI.Timeline {
             RegisterCallback<MouseMoveEvent>(OnMouseMove);
             RegisterCallback<MouseUpEvent>(OnMouseUp);
             RegisterCallback<WheelEvent>(OnWheel);
+            RegisterCallback<KeyDownEvent>(OnKeyDown);
         }
 
         public void Draw() {
@@ -218,6 +219,35 @@ namespace KexEdit.UI.Timeline {
             }
 
             evt.StopPropagation();
+        }
+
+        private void OnKeyDown(KeyDownEvent evt) {
+            if (!_data.Active) return;
+
+            if (evt.keyCode == KeyCode.V && _data.SelectedKeyframeCount == 1) {
+                int propertyIndex = 0;
+                foreach (var propertyType in _data.OrderedProperties) {
+                    var propertyData = _data.Properties[propertyType];
+                    if (!propertyData.Visible) continue;
+                    
+                    foreach (var keyframe in propertyData.Keyframes) {
+                        if (!keyframe.Selected) continue;
+                        var keyframeData = new KeyframeData(propertyType, keyframe);
+                        
+                        float x = _data.TimeToPixel(keyframe.Time);
+                        float y = (Constants.ROW_HEIGHT * propertyIndex) + (Constants.ROW_HEIGHT / 2f);
+                        var keyframePosition = new Vector2(x, y);
+                        
+                        var e = this.GetPooled<SetKeyframeValueEvent>();
+                        e.Keyframe = keyframeData;
+                        e.MousePosition = keyframePosition;
+                        this.Send(e);
+                        evt.StopPropagation();
+                        return;
+                    }
+                    propertyIndex++;
+                }
+            }
         }
     }
 }

--- a/Assets/Tests/SerializationTests.cs
+++ b/Assets/Tests/SerializationTests.cs
@@ -302,12 +302,12 @@ public class SerializationTests {
                 Assert.AreEqual(0f, graph.UIState.NodeGraphPanX, 0.001f);
                 Assert.AreEqual(0f, graph.UIState.NodeGraphPanY, 0.001f);
                 Assert.AreEqual(1f, graph.UIState.NodeGraphZoom, 0.001f);
-                Assert.AreEqual(0f, graph.UIState.CameraTargetPositionX, 0.001f);
-                Assert.AreEqual(0f, graph.UIState.CameraTargetPositionY, 0.001f);
-                Assert.AreEqual(0f, graph.UIState.CameraTargetPositionZ, 0.001f);
-                Assert.AreEqual(10f, graph.UIState.CameraTargetDistance, 0.001f);
-                Assert.AreEqual(0f, graph.UIState.CameraTargetPitch, 0.001f);
-                Assert.AreEqual(0f, graph.UIState.CameraTargetYaw, 0.001f);
+                Assert.AreEqual(6f, graph.UIState.CameraTargetPositionX, 0.001f);
+                Assert.AreEqual(6f, graph.UIState.CameraTargetPositionY, 0.001f);
+                Assert.AreEqual(6f, graph.UIState.CameraTargetPositionZ, 0.001f);
+                Assert.AreEqual(10.39230484541326f, graph.UIState.CameraTargetDistance, 0.001f);
+                Assert.AreEqual(30f, graph.UIState.CameraTargetPitch, 0.001f);
+                Assert.AreEqual(-135f, graph.UIState.CameraTargetYaw, 0.001f);
                 Assert.AreEqual(1f, graph.UIState.CameraSpeedMultiplier, 0.001f);
 
                 // Check that we have some nodes (shuttle.kex should contain data)

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.9.11
+  bundleVersion: 0.9.12
   preloadedAssets:
   - {fileID: 0}
   - {fileID: -944628639613478452, guid: e0b2dd823be4b2b4eb9c413d404801d6, type: 3}

--- a/docs/reference/timeline.md
+++ b/docs/reference/timeline.md
@@ -47,17 +47,18 @@ When a node with controllable properties is selected, the Timeline displays:
 
 ### Basic Operations
 
-| Input           | Action       | Notes                                     |
-| --------------- | ------------ | ----------------------------------------- |
-| `I`             | Insert       | Add keyframe at playhead                  |
-| `Left Click`    | Select       | Select keyframe                           |
-| `Double Click`  | Edit         | Toggle keyframe edit panel                |
-| `Shift + Click` | Multi-Select | Add to selection                          |
-| `Drag`          | Move         | Reposition keyframe                       |
-| `Delete`        | Remove       | Delete selected keyframes                 |
-| `Ctrl+C/V`      | Copy/Paste   | Duplicate keyframes                       |
-| `Box Select`    | Multi-Select | Drag to select multiple                   |
-| `Right Click`   | Context Menu | Optimize, change interpolation type, etc. |
+| Input           | Action       | Notes                                    |
+| --------------- | ------------ | ---------------------------------------- |
+| `I`             | Insert       | Add keyframe at playhead                 |
+| `Left Click`    | Select       | Select keyframe                          |
+| `Double Click`  | Edit         | Toggle keyframe edit panel               |
+| `V`             | Set Value    | Quick value editor for selected keyframe |
+| `Shift + Click` | Multi-Select | Add to selection                         |
+| `Drag`          | Move         | Reposition keyframe                      |
+| `Delete`        | Remove       | Delete selected keyframes                |
+| `Ctrl+C/V`      | Copy/Paste   | Duplicate keyframes                      |
+| `Box Select`    | Multi-Select | Drag to select multiple                  |
+| `Right Click`   | Context Menu | Edit, Optimize, etc.                     |
 
 ### Curve View Controls
 


### PR DESCRIPTION
- Added float field scrolling to keyframe editing panel and node graph inputs
- Added render toggle to Mesh nodes
- Added back old quick keyframe value edit popup, now with Edit -> Set Value or the `V` hotkey
- Fixed bug where Undo/Redo unintentionally applied to camera
- Fixed bug incorrectly adding rotation to mesh nodes