### PR TITLE
Mac enhanced support

### DIFF
--- a/Assets/Scripts/UI/ControlsDialog.cs
+++ b/Assets/Scripts/UI/ControlsDialog.cs
@@ -70,13 +70,13 @@ namespace KexEdit.UI {
                     ("Mouse Wheel", "Zoom")
                 }),
                 ("Camera Views", new[] {
-                    ("Numpad 1", "Front View"),
-                    ("Ctrl+Numpad 1".ToPlatformShortcut(), "Back View"),
-                    ("Numpad 3", "Right View"),
-                    ("Ctrl+Numpad 3".ToPlatformShortcut(), "Left View"),
-                    ("Numpad 5", "Toggle Orthographic"),
-                    ("Numpad 7", "Top View"),
-                    ("Ctrl+Numpad 7".ToPlatformShortcut(), "Bottom View")
+                    (Preferences.EnableTopRowViewHotkeys ? "1 or Numpad 1" : "Numpad 1", "Front View"),
+                    (Preferences.EnableTopRowViewHotkeys ? "Ctrl+1 or Ctrl+Numpad 1".ToPlatformShortcut() : "Ctrl+Numpad 1".ToPlatformShortcut(), "Back View"),
+                    (Preferences.EnableTopRowViewHotkeys ? "3 or Numpad 3" : "Numpad 3", "Right View"),
+                    (Preferences.EnableTopRowViewHotkeys ? "Ctrl+3 or Ctrl+Numpad 3".ToPlatformShortcut() : "Ctrl+Numpad 3".ToPlatformShortcut(), "Left View"),
+                    (Preferences.EnableTopRowViewHotkeys ? "5 or Numpad 5" : "Numpad 5", "Toggle Orthographic"),
+                    (Preferences.EnableTopRowViewHotkeys ? "7 or Numpad 7" : "Numpad 7", "Top View"),
+                    (Preferences.EnableTopRowViewHotkeys ? "Ctrl+7 or Ctrl+Numpad 7".ToPlatformShortcut() : "Ctrl+Numpad 7".ToPlatformShortcut(), "Bottom View")
                 }),
                 ("Free Look Mode", new[] {
                     ("Right-Click + Hold", "Activate Free Look"),

--- a/Assets/Scripts/UI/NodeGraph/NodeGraphView.cs
+++ b/Assets/Scripts/UI/NodeGraph/NodeGraphView.cs
@@ -4,6 +4,7 @@ using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.UIElements;
+using KexEdit.UI;
 using static KexEdit.UI.Constants;
 
 namespace KexEdit.UI.NodeGraph {
@@ -351,6 +352,7 @@ namespace KexEdit.UI.NodeGraph {
 
             if (_panning) {
                 Vector2 delta = evt.localMousePosition - _startMousePosition;
+                delta = Preferences.AdjustPointerDelta(delta);
                 _data.Pan += delta;
                 _content.transform.position = _data.Pan;
                 _startMousePosition = evt.localMousePosition;
@@ -384,7 +386,7 @@ namespace KexEdit.UI.NodeGraph {
             Vector2 mousePos = evt.mousePosition;
             Vector2 contentSpaceMousePos = (mousePos - _data.Pan) / _data.Zoom;
 
-            float zoomDelta = -evt.delta.y * ZOOM_SPEED;
+            float zoomDelta = -Preferences.AdjustScroll(evt.delta.y) * ZOOM_SPEED;
             float multiplier = zoomDelta > 0 ? 1.1f : 1f / 1.1f;
             _data.Zoom = Mathf.Clamp(_data.Zoom * Mathf.Pow(multiplier, Mathf.Abs(zoomDelta)), MIN_ZOOM, MAX_ZOOM);
 

--- a/Assets/Scripts/UI/Preferences.cs
+++ b/Assets/Scripts/UI/Preferences.cs
@@ -40,6 +40,11 @@ namespace KexEdit.UI {
         private const string PREF_VIS_CURVATURE_MIN = "VisCurvatureMin";
         private const string PREF_VIS_CURVATURE_MAX = "VisCurvatureMax";
 
+        private const string PREF_SCROLL_INVERT = "ScrollInvert";
+        private const string PREF_SCROLL_SENSITIVITY = "ScrollSensitivity";
+        private const string PREF_POINTER_SENSITIVITY = "PointerSensitivity";
+        private const string PREF_ENABLE_TOPROW_VIEW_HOTKEYS = "EnableTopRowViewHotkeys";
+
         private static DistanceUnitsType s_DistanceUnits;
         private static AngleUnitsType s_AngleUnits;
         private static AngleChangeUnitsType s_AngleChangeUnits;
@@ -61,6 +66,11 @@ namespace KexEdit.UI {
         private static bool s_KeyframeEditor;
         private static bool s_ShowGizmos;
         private static bool s_AutoStyle;
+
+        private static bool s_ScrollInvert;
+        private static float s_ScrollSensitivity;
+        private static float s_PointerSensitivity;
+        private static bool s_EnableTopRowViewHotkeys;
 
         static Preferences() {
             LoadPreferences();
@@ -246,6 +256,55 @@ namespace KexEdit.UI {
             }
         }
 
+        public static bool InvertScroll {
+            get => s_ScrollInvert;
+            set {
+                s_ScrollInvert = value;
+                PlayerPrefs.SetInt(PREF_SCROLL_INVERT, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static float ScrollSensitivity {
+            get => s_ScrollSensitivity;
+            set {
+                s_ScrollSensitivity = Mathf.Clamp(value, 0.1f, 3f);
+                PlayerPrefs.SetFloat(PREF_SCROLL_SENSITIVITY, s_ScrollSensitivity);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static float PointerSensitivity {
+            get => s_PointerSensitivity;
+            set {
+                s_PointerSensitivity = Mathf.Clamp(value, 0.1f, 3f);
+                PlayerPrefs.SetFloat(PREF_POINTER_SENSITIVITY, s_PointerSensitivity);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static bool EnableTopRowViewHotkeys {
+            get => s_EnableTopRowViewHotkeys;
+            set {
+                s_EnableTopRowViewHotkeys = value;
+                PlayerPrefs.SetInt(PREF_ENABLE_TOPROW_VIEW_HOTKEYS, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static float AdjustScroll(float deltaY) {
+            float sign = s_ScrollInvert ? -1f : 1f;
+            return deltaY * sign * s_ScrollSensitivity;
+        }
+
+        public static float2 AdjustPointerDelta(float2 delta) {
+            return delta * s_PointerSensitivity;
+        }
+
+        public static Vector2 AdjustPointerDelta(Vector2 delta) {
+            return delta * s_PointerSensitivity;
+        }
+
         public static float GetDefaultUIScale() {
             float dpi = Screen.dpi;
             if (dpi <= 96f) return 1f;
@@ -276,6 +335,17 @@ namespace KexEdit.UI {
             s_KeyframeEditor = PlayerPrefs.GetInt(PREF_KEYFRAME_EDITOR, 0) == 1;
             s_ShowGizmos = PlayerPrefs.GetInt(PREF_SHOW_GIZMOS, 0) == 1;
             s_AutoStyle = PlayerPrefs.GetInt(PREF_AUTO_STYLE, 0) == 1;
+
+            bool isMac = Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer;
+            float defaultScrollSensitivity = isMac ? 0.7f : 1f;
+            float defaultPointerSensitivity = isMac ? 0.8f : 1f;
+            bool defaultInvertScroll = isMac; // Match natural scroll on macOS
+            bool defaultEnableTopRow = true;
+
+            s_ScrollInvert = PlayerPrefs.GetInt(PREF_SCROLL_INVERT, defaultInvertScroll ? 1 : 0) == 1;
+            s_ScrollSensitivity = PlayerPrefs.GetFloat(PREF_SCROLL_SENSITIVITY, defaultScrollSensitivity);
+            s_PointerSensitivity = PlayerPrefs.GetFloat(PREF_POINTER_SENSITIVITY, defaultPointerSensitivity);
+            s_EnableTopRowViewHotkeys = PlayerPrefs.GetInt(PREF_ENABLE_TOPROW_VIEW_HOTKEYS, defaultEnableTopRow ? 1 : 0) == 1;
         }
 
         public static float2 GetVisualizationRange(VisualizationMode mode) {

--- a/Assets/Scripts/UI/Systems/EditOperationsSystem.cs
+++ b/Assets/Scripts/UI/Systems/EditOperationsSystem.cs
@@ -33,7 +33,10 @@ namespace KexEdit.UI {
         private void ProcessKeyboardShortcuts() {
             var kb = Keyboard.current;
 
-            if (kb.deleteKey.wasPressedThisFrame) HandleDelete();
+            // Do not process global edit shortcuts when typing into text inputs
+            if (Extensions.IsTextInputActive()) return;
+
+            if (kb.deleteKey.wasPressedThisFrame || kb.backspaceKey.wasPressedThisFrame) HandleDelete();
             else if (kb.fKey.wasPressedThisFrame) HandleFocus();
 
             if (kb.ctrlKey.isPressed || kb.leftCommandKey.isPressed) {

--- a/Assets/Scripts/UI/Systems/OrbitCameraSystem.cs
+++ b/Assets/Scripts/UI/Systems/OrbitCameraSystem.cs
@@ -134,6 +134,7 @@ namespace KexEdit.UI {
 
             if (_isOrbiting || _isPanning || _isFreeLooking) {
                 mouseDelta = currentMousePosition - _lastMousePosition;
+                mouseDelta = Preferences.AdjustPointerDelta(mouseDelta);
             }
 
             if (_isOverGameView) {
@@ -196,7 +197,7 @@ namespace KexEdit.UI {
                 _freeLookPitch -= mouseDelta.y * CameraProperties.FreeLookSpeed * 0.01f;
                 _freeLookPitch = math.clamp(_freeLookPitch, -89f, 89f);
 
-                float scroll = mouse.scroll.ReadValue().y;
+                float scroll = Preferences.AdjustScroll(mouse.scroll.ReadValue().y);
                 if (math.abs(scroll) > 0.01f) {
                     if (scroll > 0f) {
                         cameraState.SpeedMultiplier += CameraProperties.SpeedMultiplierStep;
@@ -248,7 +249,7 @@ namespace KexEdit.UI {
             }
 
             if (_isOverGameView && !_isFreeLooking) {
-                float scroll = mouse.scroll.ReadValue().y;
+                float scroll = Preferences.AdjustScroll(mouse.scroll.ReadValue().y);
                 if (math.abs(scroll) > 0.01f) {
                     float zoomAmount = scroll * CameraProperties.ZoomSpeed * cameraState.TargetDistance;
                     cameraState.TargetDistance -= zoomAmount;

--- a/Assets/Scripts/UI/Systems/ProjectOperationsSystem.cs
+++ b/Assets/Scripts/UI/Systems/ProjectOperationsSystem.cs
@@ -47,6 +47,7 @@ namespace KexEdit.UI {
                 AddFileMenu(menuBar);
                 AddEditMenu(menuBar);
                 AddViewMenu(menuBar);
+                AddPreferencesMenu(menuBar);
                 AddHelpMenu(menuBar);
 
                 _titleLabel = new Label("Untitled") {
@@ -279,6 +280,46 @@ namespace KexEdit.UI {
             });
         }
 
+        private void AddPreferencesMenu(MenuBar menuBar) {
+            menuBar.AddMenu("Preferences", menu => {
+                menu.AddSubmenu("Input", submenu => {
+                    submenu.AddItem("Invert Scroll Direction", () => Preferences.InvertScroll = !Preferences.InvertScroll,
+                        isChecked: Preferences.InvertScroll);
+                    submenu.AddSeparator();
+                    submenu.AddSubmenu("Scroll Sensitivity", sens => {
+                        sens.AddItem("0.5x", () => Preferences.ScrollSensitivity = 0.5f,
+                            isChecked: Mathf.Abs(Preferences.ScrollSensitivity - 0.5f) < 0.001f);
+                        sens.AddItem("0.75x", () => Preferences.ScrollSensitivity = 0.75f,
+                            isChecked: Mathf.Abs(Preferences.ScrollSensitivity - 0.75f) < 0.001f);
+                        sens.AddItem("1.0x", () => Preferences.ScrollSensitivity = 1.0f,
+                            isChecked: Mathf.Abs(Preferences.ScrollSensitivity - 1.0f) < 0.001f);
+                        sens.AddItem("1.5x", () => Preferences.ScrollSensitivity = 1.5f,
+                            isChecked: Mathf.Abs(Preferences.ScrollSensitivity - 1.5f) < 0.001f);
+                        sens.AddItem("2.0x", () => Preferences.ScrollSensitivity = 2.0f,
+                            isChecked: Mathf.Abs(Preferences.ScrollSensitivity - 2.0f) < 0.001f);
+                    });
+                    submenu.AddSubmenu("Pointer Sensitivity", sens => {
+                        sens.AddItem("0.5x", () => Preferences.PointerSensitivity = 0.5f,
+                            isChecked: Mathf.Abs(Preferences.PointerSensitivity - 0.5f) < 0.001f);
+                        sens.AddItem("0.75x", () => Preferences.PointerSensitivity = 0.75f,
+                            isChecked: Mathf.Abs(Preferences.PointerSensitivity - 0.75f) < 0.001f);
+                        sens.AddItem("1.0x", () => Preferences.PointerSensitivity = 1.0f,
+                            isChecked: Mathf.Abs(Preferences.PointerSensitivity - 1.0f) < 0.001f);
+                        sens.AddItem("1.5x", () => Preferences.PointerSensitivity = 1.5f,
+                            isChecked: Mathf.Abs(Preferences.PointerSensitivity - 1.5f) < 0.001f);
+                        sens.AddItem("2.0x", () => Preferences.PointerSensitivity = 2.0f,
+                            isChecked: Mathf.Abs(Preferences.PointerSensitivity - 2.0f) < 0.001f);
+                    });
+                });
+
+                menu.AddSubmenu("Hotkeys", submenu => {
+                    submenu.AddItem("Enable Top-Row Camera View Shortcuts (1/3/5/7)",
+                        () => Preferences.EnableTopRowViewHotkeys = !Preferences.EnableTopRowViewHotkeys,
+                        isChecked: Preferences.EnableTopRowViewHotkeys);
+                });
+            });
+        }
+
         private void AddHelpMenu(MenuBar menuBar) {
             menuBar.AddMenu("Help", menu => {
                 menu.AddItem("About", ShowAbout);
@@ -380,6 +421,7 @@ namespace KexEdit.UI {
 
         protected override void OnUpdate() {
             var kb = Keyboard.current;
+            bool textEditing = Extensions.IsTextInputActive();
 
             if (!kb.ctrlKey.isPressed && !kb.leftCommandKey.isPressed) {
                 if (kb.f1Key.wasPressedThisFrame) ToggleShowGizmos();
@@ -389,10 +431,14 @@ namespace KexEdit.UI {
                 else if (kb.f11Key.wasPressedThisFrame) VideoControlSystem.Instance?.ToggleFullscreen();
                 else if (kb.iKey.wasPressedThisFrame) AddKeyframe();
                 else if (kb.tKey.wasPressedThisFrame) ToggleSyncPlayback();
-                else if (!Extensions.IsTextInputActive() && kb.numpad1Key.wasPressedThisFrame) OrbitCameraSystem.SetFrontView();
-                else if (!Extensions.IsTextInputActive() && kb.numpad3Key.wasPressedThisFrame) OrbitCameraSystem.SetSideView();
-                else if (!Extensions.IsTextInputActive() && kb.numpad5Key.wasPressedThisFrame) OrbitCameraSystem.ToggleOrthographic();
-                else if (!Extensions.IsTextInputActive() && kb.numpad7Key.wasPressedThisFrame) OrbitCameraSystem.SetTopView();
+                else if (!textEditing && kb.numpad1Key.wasPressedThisFrame) OrbitCameraSystem.SetFrontView();
+                else if (!textEditing && kb.numpad3Key.wasPressedThisFrame) OrbitCameraSystem.SetSideView();
+                else if (!textEditing && kb.numpad5Key.wasPressedThisFrame) OrbitCameraSystem.ToggleOrthographic();
+                else if (!textEditing && kb.numpad7Key.wasPressedThisFrame) OrbitCameraSystem.SetTopView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit1Key.wasPressedThisFrame) OrbitCameraSystem.SetFrontView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit3Key.wasPressedThisFrame) OrbitCameraSystem.SetSideView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit5Key.wasPressedThisFrame) OrbitCameraSystem.ToggleOrthographic();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit7Key.wasPressedThisFrame) OrbitCameraSystem.SetTopView();
             }
 
             if (kb.ctrlKey.isPressed || kb.leftCommandKey.isPressed) {
@@ -404,19 +450,22 @@ namespace KexEdit.UI {
                 else if (kb.nKey.wasPressedThisFrame) NewProject();
                 else if (kb.oKey.wasPressedThisFrame) OpenProject();
                 else if (kb.sKey.wasPressedThisFrame) SaveProject();
-                else if (kb.hKey.wasPressedThisFrame) ShowControls();
+                else if (!textEditing && kb.hKey.wasPressedThisFrame) ShowControls();
                 else if (kb.equalsKey.wasPressedThisFrame || kb.numpadPlusKey.wasPressedThisFrame) UIScaleSystem.Instance?.ZoomIn();
                 else if (kb.minusKey.wasPressedThisFrame || kb.numpadMinusKey.wasPressedThisFrame) UIScaleSystem.Instance?.ZoomOut();
-                else if (kb.digit1Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.Velocity);
-                else if (kb.digit2Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.Curvature);
-                else if (kb.digit3Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.NormalForce);
-                else if (kb.digit4Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.LateralForce);
-                else if (kb.digit5Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.RollSpeed);
-                else if (kb.digit6Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.PitchSpeed);
-                else if (kb.digit7Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.YawSpeed);
-                else if (!Extensions.IsTextInputActive() && kb.numpad1Key.wasPressedThisFrame) OrbitCameraSystem.SetBackView();
-                else if (!Extensions.IsTextInputActive() && kb.numpad3Key.wasPressedThisFrame) OrbitCameraSystem.SetOtherSideView();
-                else if (!Extensions.IsTextInputActive() && kb.numpad7Key.wasPressedThisFrame) OrbitCameraSystem.SetBottomView();
+                else if (!textEditing && kb.digit1Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.Velocity);
+                else if (!textEditing && kb.digit2Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.Curvature);
+                else if (!textEditing && kb.digit3Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.NormalForce);
+                else if (!textEditing && kb.digit4Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.LateralForce);
+                else if (!textEditing && kb.digit5Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.RollSpeed);
+                else if (!textEditing && kb.digit6Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.PitchSpeed);
+                else if (!textEditing && kb.digit7Key.wasPressedThisFrame) VisualizationSystem.SetMode(VisualizationMode.YawSpeed);
+                else if (!textEditing && kb.numpad1Key.wasPressedThisFrame) OrbitCameraSystem.SetBackView();
+                else if (!textEditing && kb.numpad3Key.wasPressedThisFrame) OrbitCameraSystem.SetOtherSideView();
+                else if (!textEditing && kb.numpad7Key.wasPressedThisFrame) OrbitCameraSystem.SetBottomView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit1Key.wasPressedThisFrame) OrbitCameraSystem.SetBackView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit3Key.wasPressedThisFrame) OrbitCameraSystem.SetOtherSideView();
+                else if (Preferences.EnableTopRowViewHotkeys && !textEditing && kb.digit7Key.wasPressedThisFrame) OrbitCameraSystem.SetBottomView();
             }
         }
 

--- a/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
+++ b/Assets/Scripts/UI/Timeline/Systems/TimelineControlSystem.cs
@@ -233,6 +233,7 @@ namespace KexEdit.UI.Timeline {
             if (!_data.Active) return;
 
             var kb = Keyboard.current;
+            if (UI.Extensions.IsTextInputActive()) return;
             if (!kb.leftShiftKey.isPressed && !kb.rightShiftKey.isPressed) return;
 
             var visibleProperties = new List<PropertyType>();

--- a/Assets/Scripts/UI/Timeline/TimelineView.cs
+++ b/Assets/Scripts/UI/Timeline/TimelineView.cs
@@ -4,6 +4,7 @@ using Unity.Properties;
 using static KexEdit.UI.Constants;
 using static KexEdit.UI.Timeline.Constants;
 using Unity.Mathematics;
+using KexEdit.UI;
 
 namespace KexEdit.UI.Timeline {
     public class TimelineView : VisualElement {
@@ -162,6 +163,7 @@ namespace KexEdit.UI.Timeline {
 
             if (_panning) {
                 Vector2 delta = evt.localMousePosition - _prevMousePosition;
+                delta = Preferences.AdjustPointerDelta(delta);
                 _data.Offset -= delta.x;
                 _data.ClampOffset();
                 _prevMousePosition = evt.localMousePosition;
@@ -188,7 +190,7 @@ namespace KexEdit.UI.Timeline {
 
             if (evt.shiftKey) {
                 const float panSpeed = 15f;
-                _data.Offset += evt.delta.y * panSpeed;
+                _data.Offset += Preferences.AdjustScroll(evt.delta.y) * panSpeed;
                 _data.ClampOffset();
                 
                 var e = this.GetPooled<TimelineOffsetChangeEvent>();
@@ -196,7 +198,7 @@ namespace KexEdit.UI.Timeline {
                 this.Send(e);
             }
             else {
-                float zoomMultiplier = 1f - evt.delta.y * ZOOM_SPEED;
+                float zoomMultiplier = 1f - Preferences.AdjustScroll(evt.delta.y) * ZOOM_SPEED;
                 float newZoom = _data.Zoom * zoomMultiplier;
                 newZoom = Mathf.Clamp(newZoom, MIN_ZOOM, MAX_ZOOM);
 


### PR DESCRIPTION
**Summary**
Improve macOS usability: configurable scroll direction and sensitivity, pointer sensitivity, optional top-row camera hotkeys, and more robust shortcut handling (no interference with text input; Delete works on mac).

**Changes**
Input preferences
Added Invert Scroll, Scroll Sensitivity, Pointer Sensitivity with sensible macOS defaults.
Applied across 3D Game View (orbit/fly/zoom), Node Graph (pan/zoom), and Timeline (pan/zoom).
Hotkeys
Optional top-row camera view shortcuts (1/3/5/7 as alternatives to numpad 1/3/5/7), toggleable in Preferences.
Suppress all app shortcuts while typing in input fields to avoid conflicts (e.g., entering digits in editors).
Treat Backspace as Delete for mac keyboards.
UI
New “Preferences” menu: Input (invert + sensitivity presets) and Hotkeys (top-row camera shortcuts toggle).
Controls dialog reflects the chosen camera shortcut mode.

**Rationale**
macOS trackpad users get natural-feeling scroll/zoom and pointer movement.
Laptops without a numpad can use camera view shortcuts.
Text entry no longer triggers unrelated shortcuts.
Delete behavior aligned with mac keyboards.

Note : Tested on Mac only, some of the changes are only targeting Mac while other are affecting all scopes. Testing is required on other builds.

https://github.com/user-attachments/assets/1458febd-80d7-464e-be07-df3f8511f17b
